### PR TITLE
Re-authenticate characters with stale ESI tokens

### DIFF
--- a/app/helpers/esi_helper.rb
+++ b/app/helpers/esi_helper.rb
@@ -26,6 +26,11 @@ module ESIHelper
     link_to(esi_login_url) { esi_login_image }
   end
 
+  def reauth_character_button(character)
+    classes = character.needs_reauth? ? 'btn btn-warning btn-sm' : 'btn btn-outline-secondary btn-sm'
+    link_to('Re-authenticate', esi_login_url('character'), class: classes)
+  end
+
   def esi_login_url(intention = 'account', custom_params = {})
     custom_params[:state] = "#{intention}-#{Time.now.to_i}"
     uri = URI(ESI_URL)

--- a/app/helpers/esi_helper.rb
+++ b/app/helpers/esi_helper.rb
@@ -27,7 +27,7 @@ module ESIHelper
   end
 
   def reauth_character_button(character)
-    classes = character.needs_reauth? ? 'btn btn-warning btn-sm' : 'btn btn-outline-secondary btn-sm'
+    classes = character.reauth_required? ? 'btn btn-warning btn-sm' : 'btn btn-outline-secondary btn-sm'
     link_to('Re-authenticate', esi_login_url('character'), class: classes)
   end
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -41,10 +41,6 @@ class Character < ApplicationRecord
     esi_auth_token
   end
 
-  def needs_reauth?
-    reauth_required?
-  end
-
   def avatar
     return character_portrait if character_portrait.present?
 

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -15,6 +15,7 @@
 #  owner_hash         :string
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
+#  reauth_required    :boolean          default(FALSE), not null
 #
 class Character < ApplicationRecord
   belongs_to :user
@@ -31,14 +32,17 @@ class Character < ApplicationRecord
   end
 
   def auth_token
-    # Treat tokens as expired 5 seconds earlier
-    expired_token = DateTime.now.utc + 5.seconds >= esi_expires_on
-    return esi_auth_token unless expired_token
+    return esi_auth_token unless token_expired?
 
     auth_response = ESI.authenticate(esi_refresh_token, refresh: true)
+    return mark_reauth_required if auth_response.nil?
 
-    self.esi_refresh_token = auth_response['refresh_token']
-    self.esi_auth_token = auth_response['access_token']
+    apply_refreshed_token(auth_response)
+    esi_auth_token
+  end
+
+  def needs_reauth?
+    reauth_required?
   end
 
   def avatar
@@ -47,5 +51,27 @@ class Character < ApplicationRecord
     portraits = ESI.fetch_character_portrait(character_id)
     update(character_portrait: portraits['px64x64'])
     character_portrait
+  end
+
+  private
+
+  def token_expired?
+    # Treat tokens as expired 5 seconds earlier
+    DateTime.now.utc + 5.seconds >= esi_expires_on
+  end
+
+  def apply_refreshed_token(auth_response)
+    assign_attributes(
+      esi_refresh_token: auth_response['refresh_token'],
+      esi_auth_token: auth_response['access_token'],
+      esi_expires_on: DateTime.now.utc + auth_response['expires_in'].to_i.seconds,
+      reauth_required: false
+    )
+    save! if persisted?
+  end
+
+  def mark_reauth_required
+    update!(reauth_required: true) if persisted?
+    nil
   end
 end

--- a/app/models/character.rb
+++ b/app/models/character.rb
@@ -39,6 +39,9 @@ class Character < ApplicationRecord
 
     apply_refreshed_token(auth_response)
     esi_auth_token
+  rescue StandardError => e
+    Rails.logger.warn("ESI token refresh failed for character #{id}: #{e.message}")
+    nil
   end
 
   def avatar

--- a/app/models/esi.rb
+++ b/app/models/esi.rb
@@ -12,9 +12,10 @@ class ESI
       http.request(request)
     end
 
-    return nil unless res.is_a?(Net::HTTPOK)
+    return JSON.parse(res.body) if res.is_a?(Net::HTTPOK)
+    return nil if res.is_a?(Net::HTTPClientError)
 
-    JSON.parse(res.body)
+    raise "ESI authentication failed: #{res.code} #{res.message}"
   end
 
   def self.verify_access_token(access_token)

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -50,12 +50,12 @@ class Order < ApplicationRecord
 
   def self.update_character_orders(character, update_competition: true)
     start_time = Time.current
-    orders = ESI.fetch_character_market_orders(character)
+    orders = fetch_character_orders(character)
+    return if orders.nil?
+
     item_ids = orders.pluck("type_id").uniq
     Item.create_items(item_ids)
-    orders.each do |esi_order|
-      upsert_order(esi_order, character:, region_id: esi_order["region_id"])
-    end
+    orders.each { |esi_order| upsert_order(esi_order, character:, region_id: esi_order["region_id"]) }
 
     return unless update_competition
 
@@ -86,6 +86,14 @@ class Order < ApplicationRecord
         end
       orders.delete_all
     end
+  end
+
+  private_class_method def self.fetch_character_orders(character)
+    orders = ESI.fetch_character_market_orders(character)
+    return orders if orders.is_a?(Array)
+
+    Rails.logger.warn("Skipping orders for character #{character.id}: ESI returned #{orders.inspect}")
+    nil
   end
 
   private_class_method def self.update_region_orders(region_id, item_ids)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -54,6 +54,7 @@ class User < ApplicationRecord
       c.esi_auth_token = auth_response['access_token']
       c.esi_refresh_token = auth_response['refresh_token']
       c.verification_data = verification_data
+      c.reauth_required = false
       c.save!
     end
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
     <nav class="navbar navbar-expand-md navbar-dark bg-dark fixed-top">
       <div class="container">
         <%= link_to 'EVE-Industrial', root_path, class: 'navbar-brand' %>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar_collapse" aria-controls="navbar_collapse" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar_collapse" aria-controls="navbar_collapse" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
 
@@ -37,11 +37,11 @@
           </ul>
           <% if signed_in? %>
             <div class="btn-group navbar-nav">
-              <a class="nav-link" href="#" id="user_menu" data-toggle="dropdown" aria-expanded="false">
+              <a class="nav-link" href="#" id="user_menu" data-bs-toggle="dropdown" aria-expanded="false">
                 <%= current_user.character_name %>
                 <%= image_tag current_user.avatar, class: 'user-avatar' %>
               </a>
-              <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="user_menu">
+              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="user_menu">
                 <li><%= link_to 'Settings', settings_path, class: 'dropdown-item' %></li>
                 <li><%= button_to 'Logout', logout_path, method: :delete, class: 'dropdown-item' %></li>
               </ul>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -12,7 +12,7 @@
         <div class="d-flex justify-content-between align-items-center">
           <h3>
             <%= c.character_name %>
-            <% if c.needs_reauth? %>
+            <% if c.reauth_required? %>
               <span class="badge bg-warning text-dark">Needs re-authentication</span>
             <% end %>
           </h3>

--- a/app/views/users/settings.html.erb
+++ b/app/views/users/settings.html.erb
@@ -9,9 +9,17 @@
       <%= image_tag c.avatar, class: 'character-avatar' %>
 
       <div class="pb-3 mb-0 small lh-sm border-bottom w-100">
-        <div class="d-flex justify-content-between">
-          <h3><%= c.character_name %></h3>
-          <%= button_to 'Delete', remove_character_path(c), method: :delete, class: 'btn btn-danger' %>
+        <div class="d-flex justify-content-between align-items-center">
+          <h3>
+            <%= c.character_name %>
+            <% if c.needs_reauth? %>
+              <span class="badge bg-warning text-dark">Needs re-authentication</span>
+            <% end %>
+          </h3>
+          <div class="d-flex gap-2">
+            <%= reauth_character_button(c) %>
+            <%= button_to 'Delete', remove_character_path(c), method: :delete, class: 'btn btn-danger btn-sm' %>
+          </div>
         </div>
       </div>
     </div>

--- a/db/migrate/20260608000000_add_reauth_required_to_characters.rb
+++ b/db/migrate/20260608000000_add_reauth_required_to_characters.rb
@@ -1,0 +1,5 @@
+class AddReauthRequiredToCharacters < ActiveRecord::Migration[7.0]
+  def change
+    add_column :characters, :reauth_required, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_17_034836) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -23,6 +23,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_17_034836) do
     t.datetime "esi_expires_on", precision: nil
     t.string "esi_refresh_token"
     t.string "owner_hash"
+    t.boolean "reauth_required", default: false, null: false
     t.string "scopes"
     t.string "token_type"
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,48 +10,48 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_05_17_034836) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_17_034836) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "characters", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "esi_refresh_token"
-    t.string "esi_auth_token"
-    t.datetime "esi_expires_on", precision: nil
     t.bigint "character_id"
     t.string "character_name"
     t.string "character_portrait"
+    t.datetime "created_at", null: false
+    t.string "esi_auth_token"
+    t.datetime "esi_expires_on", precision: nil
+    t.string "esi_refresh_token"
+    t.string "owner_hash"
     t.string "scopes"
     t.string "token_type"
-    t.string "owner_hash"
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
     t.index ["user_id"], name: "index_characters_on_user_id"
   end
 
   create_table "constellations", id: false, force: :cascade do |t|
     t.bigint "id", null: false
-    t.bigint "region_id", null: false
     t.string "name", null: false
+    t.bigint "region_id", null: false
     t.index ["id"], name: "index_constellations_on_id", unique: true
     t.index ["region_id"], name: "index_constellations_on_region_id"
   end
 
   create_table "industry_jobs", id: false, force: :cascade do |t|
-    t.bigint "id", null: false
-    t.bigint "character_id"
+    t.bigint "activity_id"
     t.bigint "blueprint_id"
     t.bigint "blueprint_type_id"
-    t.bigint "product_type_id"
-    t.bigint "activity_id"
-    t.bigint "station_id"
-    t.bigint "installer_id"
-    t.datetime "start_date", precision: nil
+    t.bigint "character_id"
     t.datetime "end_date", precision: nil
-    t.integer "runs"
+    t.bigint "id", null: false
+    t.bigint "installer_id"
     t.integer "licensed_runs"
     t.decimal "probability", precision: 5, scale: 4
+    t.bigint "product_type_id"
+    t.integer "runs"
+    t.datetime "start_date", precision: nil
+    t.bigint "station_id"
     t.string "status"
     t.index ["id"], name: "index_industry_jobs_on_id", unique: true
   end
@@ -63,29 +63,29 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_17_034836) do
   end
 
   create_table "items_prices", id: false, force: :cascade do |t|
-    t.bigint "star_id", null: false
+    t.decimal "buy_price", precision: 12, scale: 2
     t.bigint "item_id", null: false
     t.string "item_type", null: false
-    t.decimal "buy_price", precision: 12, scale: 2
     t.decimal "sell_price", precision: 12, scale: 2
+    t.bigint "star_id", null: false
     t.index ["item_id", "star_id"], name: "index_items_prices_on_item_id_and_star_id"
     t.index ["star_id"], name: "index_items_prices_on_star_id"
   end
 
   create_table "orders", force: :cascade do |t|
+    t.boolean "buy_order"
     t.bigint "character_id"
-    t.bigint "item_id", null: false
-    t.bigint "region_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "duration"
     t.bigint "esi_id"
+    t.datetime "issued", precision: nil
+    t.bigint "item_id", null: false
     t.bigint "location_id"
     t.decimal "price", precision: 12, scale: 2
-    t.boolean "buy_order"
-    t.integer "duration"
+    t.bigint "region_id", null: false
+    t.datetime "updated_at", null: false
     t.integer "volume_remain"
     t.integer "volume_total"
-    t.datetime "issued", precision: nil
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["character_id"], name: "index_orders_on_character_id"
     t.index ["item_id"], name: "index_orders_on_item_id"
     t.index ["region_id"], name: "index_orders_on_region_id"
@@ -93,26 +93,26 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_17_034836) do
 
   create_table "planetary_colonies", force: :cascade do |t|
     t.bigint "character_id", null: false
-    t.bigint "star_id", null: false
-    t.bigint "planet_id", null: false
-    t.string "planet_type", null: false
-    t.integer "upgrade_level", null: false
+    t.datetime "created_at", null: false
     t.string "extractors", default: "{}"
     t.string "factories", default: "{}"
     t.datetime "last_update", precision: nil
-    t.datetime "created_at", null: false
+    t.bigint "planet_id", null: false
+    t.string "planet_type", null: false
+    t.bigint "star_id", null: false
     t.datetime "updated_at", null: false
+    t.integer "upgrade_level", null: false
     t.index ["character_id"], name: "index_planetary_colonies_on_character_id"
   end
 
   create_table "planetary_commodities", id: false, force: :cascade do |t|
+    t.integer "batch_size", null: false
     t.bigint "id", null: false
-    t.bigint "schematic_id"
+    t.text "input"
     t.string "name", null: false
+    t.bigint "schematic_id"
     t.integer "tier", null: false
     t.decimal "volume", precision: 5, scale: 2
-    t.integer "batch_size", null: false
-    t.text "input"
     t.index ["id"], name: "index_planetary_commodities_on_id", unique: true
   end
 
@@ -123,9 +123,9 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_17_034836) do
   end
 
   create_table "stars", id: false, force: :cascade do |t|
+    t.bigint "constellation_id", null: false
     t.bigint "id", null: false
     t.string "name", null: false
-    t.bigint "constellation_id", null: false
     t.bigint "region_id", null: false
     t.index ["constellation_id"], name: "index_stars_on_constellation_id"
     t.index ["id"], name: "index_stars_on_id", unique: true
@@ -133,28 +133,28 @@ ActiveRecord::Schema[7.2].define(version: 2026_05_17_034836) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "esi_refresh_token"
-    t.string "esi_auth_token"
-    t.datetime "esi_expires_on", precision: nil
     t.bigint "character_id"
     t.string "character_name"
     t.string "character_portrait"
-    t.string "scopes"
-    t.string "token_type"
-    t.string "owner_hash"
-    t.string "role"
+    t.datetime "created_at", null: false
+    t.datetime "current_sign_in_at", precision: nil
+    t.string "current_sign_in_ip"
     t.string "email"
     t.string "encrypted_password"
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at", precision: nil
+    t.string "esi_auth_token"
+    t.datetime "esi_expires_on", precision: nil
+    t.string "esi_refresh_token"
+    t.datetime "last_sign_in_at", precision: nil
+    t.string "last_sign_in_ip"
+    t.string "owner_hash"
     t.datetime "remember_created_at", precision: nil
     t.string "remember_token"
+    t.datetime "reset_password_sent_at", precision: nil
+    t.string "reset_password_token"
+    t.string "role"
+    t.string "scopes"
     t.integer "sign_in_count", default: 0, null: false
-    t.datetime "current_sign_in_at", precision: nil
-    t.datetime "last_sign_in_at", precision: nil
-    t.string "current_sign_in_ip"
-    t.string "last_sign_in_ip"
-    t.datetime "created_at", null: false
+    t.string "token_type"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["esi_refresh_token"], name: "index_users_on_esi_refresh_token", unique: true

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -75,6 +75,52 @@ RSpec.describe Character, type: :model do
         expect(character.auth_token).to eq(access_token)
       end
     end
+
+    context 'when the token is refreshed successfully' do
+      let(:character) { FactoryBot.create(:character, esi_expires_on: DateTime.now, reauth_required: true) }
+
+      before do
+        allow(ESI).to receive(:authenticate).and_return(
+          'token_type' => 'Bearer',
+          'expires_in' => 1199,
+          'access_token' => 'fresh_access_token',
+          'refresh_token' => 'fresh_refresh_token'
+        )
+      end
+
+      it 'persists the new access token' do
+        character.auth_token
+        expect(character.reload.esi_auth_token).to eq('fresh_access_token')
+      end
+
+      it 'clears the re-auth flag' do
+        expect { character.auth_token }.to change { character.reload.reauth_required }.from(true).to(false)
+      end
+    end
+
+    context 'when the refresh fails' do
+      let(:character) { FactoryBot.create(:character, esi_expires_on: DateTime.now) }
+
+      before { allow(ESI).to receive(:authenticate).and_return(nil) }
+
+      it 'returns nil' do
+        expect(character.auth_token).to be_nil
+      end
+
+      it 'flags the character for re-authentication' do
+        expect { character.auth_token }.to change { character.reload.reauth_required }.from(false).to(true)
+      end
+    end
+  end
+
+  describe '#needs_reauth?' do
+    it 'is true when re-authentication is required' do
+      expect(FactoryBot.build(:character, reauth_required: true).needs_reauth?).to be(true)
+    end
+
+    it 'is false when the token is healthy' do
+      expect(FactoryBot.build(:character, reauth_required: false).needs_reauth?).to be(false)
+    end
   end
 
   describe '#avatar' do

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -111,6 +111,20 @@ RSpec.describe Character, type: :model do
         expect { character.auth_token }.to change { character.reload.reauth_required }.from(false).to(true)
       end
     end
+
+    context 'when the refresh hits a transient error' do
+      let(:character) { FactoryBot.create(:character, esi_expires_on: DateTime.now) }
+
+      before { allow(ESI).to receive(:authenticate).and_raise(Net::OpenTimeout) }
+
+      it 'returns nil without raising' do
+        expect(character.auth_token).to be_nil
+      end
+
+      it 'does not flag the character for re-authentication' do
+        expect { character.auth_token }.not_to(change { character.reload.reauth_required })
+      end
+    end
   end
 
   describe '#avatar' do

--- a/spec/models/character_spec.rb
+++ b/spec/models/character_spec.rb
@@ -113,16 +113,6 @@ RSpec.describe Character, type: :model do
     end
   end
 
-  describe '#needs_reauth?' do
-    it 'is true when re-authentication is required' do
-      expect(FactoryBot.build(:character, reauth_required: true).needs_reauth?).to be(true)
-    end
-
-    it 'is false when the token is healthy' do
-      expect(FactoryBot.build(:character, reauth_required: false).needs_reauth?).to be(false)
-    end
-  end
-
   describe '#avatar' do
     context 'when character already has a persisted portrait' do
       let(:avatar_url) { 'https://url/portrait/character_id/portrait?size=64' }

--- a/spec/models/esi_spec.rb
+++ b/spec/models/esi_spec.rb
@@ -3,9 +3,8 @@ require "rails_helper"
 RSpec.describe ESI do
   let(:character) { FactoryBot.build(:character) }
 
-  def http_response(body, success: true)
-    klass = success ? Net::HTTPOK : Net::HTTPInternalServerError
-    klass.new("1.1", success ? "200" : "500", success ? "OK" : "Error").tap do |res|
+  def http_response(body, klass: Net::HTTPOK)
+    klass.new("1.1", "200", "OK").tap do |res|
       allow(res).to receive(:body).and_return(body)
     end
   end
@@ -27,13 +26,23 @@ RSpec.describe ESI do
       end
     end
 
-    context "when the request fails" do
+    context "when the credentials are rejected" do
       before do
-        allow(Net::HTTP).to receive(:start).and_return(http_response("error", success: false))
+        allow(Net::HTTP).to receive(:start).and_return(http_response("error", klass: Net::HTTPForbidden))
       end
 
       it "returns nil" do
         expect(authenticate).to be_nil
+      end
+    end
+
+    context "when the server errors" do
+      before do
+        allow(Net::HTTP).to receive(:start).and_return(http_response("error", klass: Net::HTTPInternalServerError))
+      end
+
+      it "raises" do
+        expect { authenticate }.to raise_error(/ESI authentication failed/)
       end
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -106,6 +106,16 @@ RSpec.describe Order, type: :model do
       expect(described_class.last).to have_attributes(esi_id: 123, character_id: character.id, price: 5.5)
     end
 
+    context "when ESI returns an error object instead of a list of orders" do
+      before do
+        allow(ESI).to receive(:fetch_character_market_orders).with(character).and_return("error" => "Forbidden")
+      end
+
+      it "skips the character without raising" do
+        expect { update }.not_to change(described_class, :count)
+      end
+    end
+
     context "when update_competition is true" do
       let(:update_competition) { true }
 


### PR DESCRIPTION
## What & why

EVE characters whose ESI refresh token has been revoked or expired had no recovery path — their data silently stopped updating. This adds detection plus a per-character re-authentication flow on `/settings`.

## How it works

- **Stale detection (lazy):** when `Character#auth_token` refreshes and EVE rejects the credential (`4xx`), the character is flagged `reauth_required` (persisted before the call returns). A successful refresh or re-auth clears it.
- **Surfacing:** `/settings` shows a "Needs re-authentication" badge and a highlighted **Re-authenticate** button for flagged characters. The button runs the existing SSO flow (`find_or_initialize_by(character_id:)`), so re-auth reuses `add_character` and resets the flag.

## Robustness

- `ESI.authenticate` now distinguishes a `4xx` credential rejection (flag for re-auth) from a `5xx`/network failure (raise — transient, don't flag). `Character#auth_token` rescues transient errors so a background job neither crashes nor false-flags a character over a blip.
- `Order.update_character_orders` skips a character when ESI returns a non-array response (auth failure, rate limit, ESI error) instead of crashing the whole `orders:import` with a `TypeError` on `pluck`.

## Also included

- **Bootstrap 5 navbar fix** (`fd69911`): the avatar dropdown/toggler used BS4 `data-toggle`/`data-target` attributes that don't work under BS5 — migrated to `data-bs-*` and `dropdown-menu-end`. This was the original starting point and is the base of the branch.
- **Schema regen for Rails 8.1** (`862f911`): the committed `db/schema.rb` was in stale Rails 7.2 format; regenerated via tooling (one-time reformat, alphabetical column order is the Rails 8 default).

## Testing

- New model specs cover the flag set/clear paths, transient-error handling, and the order-import guard.
- Migration adds `characters.reauth_required` (`boolean, default: false, null: false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)