### PR TITLE
Persist and use expires_at for EVE Tycoon price caching

### DIFF
--- a/app/models/items_prices.rb
+++ b/app/models/items_prices.rb
@@ -12,5 +12,4 @@
 class ItemsPrices < ApplicationRecord
   belongs_to :item, polymorphic: true
   belongs_to :star
-
 end

--- a/app/models/items_prices.rb
+++ b/app/models/items_prices.rb
@@ -13,13 +13,4 @@ class ItemsPrices < ApplicationRecord
   belongs_to :item, polymorphic: true
   belongs_to :star
 
-  def save!
-    return super unless persisted?
-
-    self.class.where(star_id:, item_id:).update_all(
-      buy_price:,
-      sell_price:,
-      expires_at:
-    )
-  end
 end

--- a/app/models/items_prices.rb
+++ b/app/models/items_prices.rb
@@ -7,6 +7,7 @@
 #  item_type  :string           not null
 #  buy_price  :decimal(12, 2)
 #  sell_price :decimal(12, 2)
+#  expires_at :datetime
 #
 class ItemsPrices < ApplicationRecord
   belongs_to :item, polymorphic: true
@@ -17,7 +18,8 @@ class ItemsPrices < ApplicationRecord
 
     self.class.where(star_id:, item_id:).update_all(
       buy_price:,
-      sell_price:
+      sell_price:,
+      expires_at:
     )
   end
 end

--- a/app/models/planetary_commodity.rb
+++ b/app/models/planetary_commodity.rb
@@ -62,10 +62,21 @@ class PlanetaryCommodity < ApplicationRecord
 
   private_class_method def self.update_star_prices(star_id)
     region_id = Star.find(star_id).region_id
-    fetch_prices_for(region_id:, items: stale_item_ids(star_id)).each do |price_result|
-      item_id = price_result["item_id"]
-      persist_price_data(star_id, item_id, price_result["buyAvgFivePercent"], price_result["sellAvgFivePercent"], price_result["expires_at"])
+    records = fetch_prices_for(region_id:, items: stale_item_ids(star_id)).map do |r|
+      item_price_hash(r, star_id:, item_type: name)
     end
+    ItemsPrices.upsert_all(records, unique_by: %i[item_id star_id]) if records.any?
+  end
+
+  private_class_method def self.item_price_hash(r, star_id:, item_type:)
+    {
+      star_id:,
+      item_type:,
+      item_id: r["item_id"],
+      buy_price: r["buyAvgFivePercent"],
+      sell_price: r["sellAvgFivePercent"],
+      expires_at: r["expires_at"]
+    }
   end
 
   private_class_method def self.stale_item_ids(star_id)
@@ -74,15 +85,5 @@ class PlanetaryCommodity < ApplicationRecord
       .where("expires_at > ?", Time.current)
       .pluck(:item_id)
     all_ids - fresh_ids
-  end
-
-  private_class_method def self.persist_price_data(star_id, item_id, buy_price, sell_price, expires_at = nil)
-    ItemsPrices.where(star_id:, item_id:).first_or_initialize.tap do |item_price|
-      item_price.item_type = name
-      item_price.buy_price = buy_price
-      item_price.sell_price = sell_price
-      item_price.expires_at = expires_at
-      item_price.save!
-    end
   end
 end

--- a/app/models/planetary_commodity.rb
+++ b/app/models/planetary_commodity.rb
@@ -62,17 +62,26 @@ class PlanetaryCommodity < ApplicationRecord
 
   private_class_method def self.update_star_prices(star_id)
     region_id = Star.find(star_id).region_id
-    fetch_prices_for(region_id:, items: pluck(:id)).each do |price_result|
+    fetch_prices_for(region_id:, items: stale_item_ids(star_id)).each do |price_result|
       item_id = price_result["item_id"]
-      persist_price_data(star_id, item_id, price_result["buyAvgFivePercent"], price_result["sellAvgFivePercent"])
+      persist_price_data(star_id, item_id, price_result["buyAvgFivePercent"], price_result["sellAvgFivePercent"], price_result["expires_at"])
     end
   end
 
-  private_class_method def self.persist_price_data(star_id, item_id, buy_price, sell_price)
+  private_class_method def self.stale_item_ids(star_id)
+    all_ids = pluck(:id)
+    fresh_ids = ItemsPrices.where(star_id:, item_id: all_ids)
+      .where("expires_at > ?", Time.current)
+      .pluck(:item_id)
+    all_ids - fresh_ids
+  end
+
+  private_class_method def self.persist_price_data(star_id, item_id, buy_price, sell_price, expires_at = nil)
     ItemsPrices.where(star_id:, item_id:).first_or_initialize.tap do |item_price|
       item_price.item_type = name
       item_price.buy_price = buy_price
       item_price.sell_price = sell_price
+      item_price.expires_at = expires_at
       item_price.save!
     end
   end

--- a/app/models/planetary_commodity.rb
+++ b/app/models/planetary_commodity.rb
@@ -68,14 +68,14 @@ class PlanetaryCommodity < ApplicationRecord
     ItemsPrices.upsert_all(records, unique_by: %i[item_id star_id]) if records.any?
   end
 
-  private_class_method def self.item_price_hash(r, star_id:, item_type:)
+  private_class_method def self.item_price_hash(price_data, star_id:, item_type:)
     {
       star_id:,
       item_type:,
-      item_id: r["item_id"],
-      buy_price: r["buyAvgFivePercent"],
-      sell_price: r["sellAvgFivePercent"],
-      expires_at: r["expires_at"]
+      item_id: price_data["item_id"],
+      buy_price: price_data["buyAvgFivePercent"],
+      sell_price: price_data["sellAvgFivePercent"],
+      expires_at: price_data["expires_at"]
     }
   end
 

--- a/db/migrate/20260613210653_add_expires_at_to_items_prices.rb
+++ b/db/migrate/20260613210653_add_expires_at_to_items_prices.rb
@@ -1,0 +1,5 @@
+class AddExpiresAtToItemsPrices < ActiveRecord::Migration[8.1]
+  def change
+    add_column :items_prices, :expires_at, :datetime
+  end
+end

--- a/db/migrate/20260613225433_make_items_prices_index_unique.rb
+++ b/db/migrate/20260613225433_make_items_prices_index_unique.rb
@@ -1,6 +1,6 @@
 class MakeItemsPricesIndexUnique < ActiveRecord::Migration[8.1]
   def change
-    remove_index :items_prices, [:item_id, :star_id]
-    add_index :items_prices, [:item_id, :star_id], unique: true
+    remove_index :items_prices, %i[item_id star_id]
+    add_index :items_prices, %i[item_id star_id], unique: true
   end
 end

--- a/db/migrate/20260613225433_make_items_prices_index_unique.rb
+++ b/db/migrate/20260613225433_make_items_prices_index_unique.rb
@@ -1,0 +1,6 @@
+class MakeItemsPricesIndexUnique < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :items_prices, [:item_id, :star_id]
+    add_index :items_prices, [:item_id, :star_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_13_210653) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -65,6 +65,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_000000) do
 
   create_table "items_prices", id: false, force: :cascade do |t|
     t.decimal "buy_price", precision: 12, scale: 2
+    t.datetime "expires_at"
     t.bigint "item_id", null: false
     t.string "item_type", null: false
     t.decimal "sell_price", precision: 12, scale: 2

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_210653) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_13_225433) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -70,7 +70,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_210653) do
     t.string "item_type", null: false
     t.decimal "sell_price", precision: 12, scale: 2
     t.bigint "star_id", null: false
-    t.index ["item_id", "star_id"], name: "index_items_prices_on_item_id_and_star_id"
+    t.index ["item_id", "star_id"], name: "index_items_prices_on_item_id_and_star_id", unique: true
     t.index ["star_id"], name: "index_items_prices_on_star_id"
   end
 

--- a/spec/models/items_prices_spec.rb
+++ b/spec/models/items_prices_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe ItemsPrices, type: :model do
       end
     end
 
-
     it 'raises exception trying to create invalid record' do
       invalid_instance = described_class.new(star: nil, item: nil)
       expect { invalid_instance.save! }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/models/items_prices_spec.rb
+++ b/spec/models/items_prices_spec.rb
@@ -25,32 +25,6 @@ RSpec.describe ItemsPrices, type: :model do
       end
     end
 
-    context 'when instance is already persisted' do
-      let!(:instance) { FactoryBot.create(:items_prices) }
-      let(:count) { described_class.count }
-      let(:new_buy_price) { instance.buy_price + 10 }
-      let(:new_sell_price) { instance.sell_price + 10 }
-
-      before do
-        instance.buy_price = new_buy_price
-        instance.sell_price = new_sell_price
-        save_instance
-      end
-
-      it 'updates buy price of existing record' do
-        item_price = described_class.find_by(item_id: instance.item_id, star_id: instance.star_id)
-        expect(item_price.buy_price).to eq(new_buy_price)
-      end
-
-      it 'updates sell price of existing record' do
-        item_price = described_class.find_by(item_id: instance.item_id, star_id: instance.star_id)
-        expect(item_price.sell_price).to eq(new_sell_price)
-      end
-
-      it 'does not create new records' do
-        expect(described_class.count).to eq(count)
-      end
-    end
 
     it 'raises exception trying to create invalid record' do
       invalid_instance = described_class.new(star: nil, item: nil)


### PR DESCRIPTION
## Summary

- Adds `expires_at` column to `items_prices`, populated from the `Expires` response header returned by the EVE Tycoon API
- Skips re-fetching prices that are still fresh (`expires_at > now`)
- Replaces the per-item `first_or_initialize` + `save!` loop with a single `upsert_all` call (backed by a new unique index on `(item_id, star_id)`)

## Test plan

- [ ] All existing specs pass (`bundle exec rspec`)
- [ ] Verify prices are skipped when fresh and fetched when stale
- [ ] Verify `items_prices` rows are updated in place rather than duplicated on re-run