### PR TITLE
Consolidate migrations and store ESI datetimes at second precision

### DIFF
--- a/app/models/industry_job.rb
+++ b/app/models/industry_job.rb
@@ -9,11 +9,17 @@
 #  product_type_id   :integer
 #  activity_id       :integer
 #  station_id        :integer
+#  facility_id       :integer
 #  installer_id      :integer
 #  start_date        :datetime
 #  end_date          :datetime
+#  pause_date        :datetime
+#  completed_date    :datetime
+#  duration          :integer
 #  runs              :integer
 #  licensed_runs     :integer
+#  successful_runs   :integer
+#  cost              :decimal(20, 2)
 #  probability       :decimal(5, 4)
 #  status            :string
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@
 #  reset_password_token   :string
 #  reset_password_sent_at :datetime
 #  remember_created_at    :datetime
+#  remember_token         :string
 #  sign_in_count          :integer          default(0), not null
 #  current_sign_in_at     :datetime
 #  last_sign_in_at        :datetime

--- a/db/migrate/20200917023959_create_characters.rb
+++ b/db/migrate/20200917023959_create_characters.rb
@@ -12,6 +12,7 @@ class CreateCharacters < ActiveRecord::Migration[6.0]
       t.string :scopes
       t.string :token_type
       t.string :owner_hash
+      t.boolean :reauth_required, default: false, null: false
 
       t.timestamps
     end

--- a/db/migrate/20200927060147_create_planetary_commodities.rb
+++ b/db/migrate/20200927060147_create_planetary_commodities.rb
@@ -1,4 +1,4 @@
-class CreatePlanetaryCommodities < ActiveRecord::Migration[6.0]
+class CreatePlanetaryCommodities < ActiveRecord::Migration[8.1]
   def change
     create_table :planetary_commodities, id: false do |t|
       t.bigint :id, null: false

--- a/db/migrate/20201211043127_create_items.rb
+++ b/db/migrate/20201211043127_create_items.rb
@@ -1,4 +1,4 @@
-class CreateItems < ActiveRecord::Migration[6.0]
+class CreateItems < ActiveRecord::Migration[8.1]
   def change
     create_table :items, id: false do |t|
       t.bigint :id, null: false

--- a/db/migrate/20220724172852_create_regions.rb
+++ b/db/migrate/20220724172852_create_regions.rb
@@ -1,4 +1,4 @@
-class CreateRegions < ActiveRecord::Migration[7.0]
+class CreateRegions < ActiveRecord::Migration[8.1]
   def change
     create_table :regions, id: false do |t|
       t.bigint :id, null: false

--- a/db/migrate/20220724173103_create_constellations.rb
+++ b/db/migrate/20220724173103_create_constellations.rb
@@ -1,4 +1,4 @@
-class CreateConstellations < ActiveRecord::Migration[7.0]
+class CreateConstellations < ActiveRecord::Migration[8.1]
   def change
     create_table :constellations, id: false do |t|
       t.bigint :id, null: false

--- a/db/migrate/20220724173602_create_stars.rb
+++ b/db/migrate/20220724173602_create_stars.rb
@@ -1,4 +1,4 @@
-class CreateStars < ActiveRecord::Migration[6.0]
+class CreateStars < ActiveRecord::Migration[8.1]
   def change
     create_table :stars, id: false do |t|
       t.bigint :id, null: false

--- a/db/migrate/20220724180524_create_items_prices.rb
+++ b/db/migrate/20220724180524_create_items_prices.rb
@@ -1,4 +1,4 @@
-class CreateItemsPrices < ActiveRecord::Migration[6.0]
+class CreateItemsPrices < ActiveRecord::Migration[8.1]
   def change
     create_table :items_prices, id: false do |t|
       t.references :star, null: false, foreign_key: true
@@ -7,8 +7,9 @@ class CreateItemsPrices < ActiveRecord::Migration[6.0]
 
       t.decimal :buy_price, precision: 12, scale: 2
       t.decimal :sell_price, precision: 12, scale: 2
+      t.datetime :expires_at, precision: 0
 
-      t.index %i[item_id star_id]
+      t.index %i[item_id star_id], unique: true
     end
   end
 end

--- a/db/migrate/20220724191821_create_orders.rb
+++ b/db/migrate/20220724191821_create_orders.rb
@@ -1,7 +1,7 @@
-class CreateOrders < ActiveRecord::Migration[6.0]
+class CreateOrders < ActiveRecord::Migration[8.1]
   def change
     create_table :orders do |t|
-      t.references :character, null: false, foreign_key: true
+      t.references :character, foreign_key: true
       t.references :item, null: false, foreign_key: true
       t.references :region, null: false, foreign_key: true
       t.bigint :esi_id
@@ -12,7 +12,7 @@ class CreateOrders < ActiveRecord::Migration[6.0]
       t.integer :duration
       t.integer :volume_remain
       t.integer :volume_total
-      t.datetime :issued
+      t.datetime :issued, precision: 0
 
       t.timestamps
     end

--- a/db/migrate/20220724192455_create_industry_jobs.rb
+++ b/db/migrate/20220724192455_create_industry_jobs.rb
@@ -1,4 +1,4 @@
-class CreateIndustryJobs < ActiveRecord::Migration[6.0]
+class CreateIndustryJobs < ActiveRecord::Migration[8.1]
   def change
     create_table :industry_jobs, id: false do |t|
       t.bigint :id, null: false
@@ -8,12 +8,18 @@ class CreateIndustryJobs < ActiveRecord::Migration[6.0]
       t.bigint :product_type_id
       t.bigint :activity_id
       t.bigint :station_id
+      t.bigint :facility_id
       t.bigint :installer_id
 
-      t.datetime :start_date
-      t.datetime :end_date
+      t.datetime :start_date, precision: 0
+      t.datetime :end_date, precision: 0
+      t.datetime :pause_date, precision: 0
+      t.datetime :completed_date, precision: 0
+      t.integer :duration
       t.integer :runs
       t.integer :licensed_runs
+      t.integer :successful_runs
+      t.decimal :cost, precision: 20, scale: 2
       t.decimal :probability, precision: 5, scale: 4
       t.string :status
 

--- a/db/migrate/20220724192847_create_planetary_colonies.rb
+++ b/db/migrate/20220724192847_create_planetary_colonies.rb
@@ -1,4 +1,4 @@
-class CreatePlanetaryColonies < ActiveRecord::Migration[6.0]
+class CreatePlanetaryColonies < ActiveRecord::Migration[8.1]
   def change
     create_table :planetary_colonies do |t|
       t.references :character, null: false, foreign_key: true
@@ -10,7 +10,7 @@ class CreatePlanetaryColonies < ActiveRecord::Migration[6.0]
       t.integer :upgrade_level, null: false
       t.string :extractors, default: '{}'
       t.string :factories, default: '{}'
-      t.datetime :last_update
+      t.datetime :last_update, precision: 0
       t.timestamps
     end
   end

--- a/db/migrate/20260517034836_allow_null_character_on_orders.rb
+++ b/db/migrate/20260517034836_allow_null_character_on_orders.rb
@@ -1,5 +1,0 @@
-class AllowNullCharacterOnOrders < ActiveRecord::Migration[7.0]
-  def change
-    change_column_null :orders, :character_id, true
-  end
-end

--- a/db/migrate/20260608000000_add_reauth_required_to_characters.rb
+++ b/db/migrate/20260608000000_add_reauth_required_to_characters.rb
@@ -1,5 +1,0 @@
-class AddReauthRequiredToCharacters < ActiveRecord::Migration[7.0]
-  def change
-    add_column :characters, :reauth_required, :boolean, default: false, null: false
-  end
-end

--- a/db/migrate/20260613210653_add_expires_at_to_items_prices.rb
+++ b/db/migrate/20260613210653_add_expires_at_to_items_prices.rb
@@ -1,5 +1,0 @@
-class AddExpiresAtToItemsPrices < ActiveRecord::Migration[8.1]
-  def change
-    add_column :items_prices, :expires_at, :datetime
-  end
-end

--- a/db/migrate/20260613225433_make_items_prices_index_unique.rb
+++ b/db/migrate/20260613225433_make_items_prices_index_unique.rb
@@ -1,6 +1,0 @@
-class MakeItemsPricesIndexUnique < ActiveRecord::Migration[8.1]
-  def change
-    remove_index :items_prices, %i[item_id star_id]
-    add_index :items_prices, %i[item_id star_id], unique: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_13_225433) do
+ActiveRecord::Schema[8.1].define(version: 2022_07_24_192847) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -44,16 +44,22 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_225433) do
     t.bigint "blueprint_id"
     t.bigint "blueprint_type_id"
     t.bigint "character_id"
-    t.datetime "end_date", precision: nil
+    t.datetime "completed_date", precision: 0
+    t.decimal "cost", precision: 20, scale: 2
+    t.integer "duration"
+    t.datetime "end_date", precision: 0
+    t.bigint "facility_id"
     t.bigint "id", null: false
     t.bigint "installer_id"
     t.integer "licensed_runs"
+    t.datetime "pause_date", precision: 0
     t.decimal "probability", precision: 5, scale: 4
     t.bigint "product_type_id"
     t.integer "runs"
-    t.datetime "start_date", precision: nil
+    t.datetime "start_date", precision: 0
     t.bigint "station_id"
     t.string "status"
+    t.integer "successful_runs"
     t.index ["id"], name: "index_industry_jobs_on_id", unique: true
   end
 
@@ -65,7 +71,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_225433) do
 
   create_table "items_prices", id: false, force: :cascade do |t|
     t.decimal "buy_price", precision: 12, scale: 2
-    t.datetime "expires_at"
+    t.datetime "expires_at", precision: 0
     t.bigint "item_id", null: false
     t.string "item_type", null: false
     t.decimal "sell_price", precision: 12, scale: 2
@@ -80,7 +86,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_225433) do
     t.datetime "created_at", null: false
     t.integer "duration"
     t.bigint "esi_id"
-    t.datetime "issued", precision: nil
+    t.datetime "issued", precision: 0
     t.bigint "item_id", null: false
     t.bigint "location_id"
     t.decimal "price", precision: 12, scale: 2
@@ -98,7 +104,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_13_225433) do
     t.datetime "created_at", null: false
     t.string "extractors", default: "{}"
     t.string "factories", default: "{}"
-    t.datetime "last_update", precision: nil
+    t.datetime "last_update", precision: 0
     t.bigint "planet_id", null: false
     t.string "planet_type", null: false
     t.bigint "star_id", null: false

--- a/spec/factories/industry_job_factory.rb
+++ b/spec/factories/industry_job_factory.rb
@@ -6,11 +6,17 @@ FactoryBot.define do
   #  product_type_id   :integer
   #  activity_id       :integer
   #  station_id        :integer
+  #  facility_id       :integer
   #  installer_id      :integer
   #  start_date        :datetime
   #  end_date          :datetime
+  #  pause_date        :datetime
+  #  completed_date    :datetime
+  #  duration          :integer
   #  runs              :integer
   #  licensed_runs     :integer
+  #  successful_runs   :integer
+  #  cost              :decimal(20, 2)
   #  probability       :decimal(5, 4)
   #  status            :string
   #

--- a/spec/factories/order_factory.rb
+++ b/spec/factories/order_factory.rb
@@ -11,6 +11,8 @@ FactoryBot.define do
   #  volume_remain :integer
   #  volume_total  :integer
   #  buy_order     :boolean
+  #  created_at    :datetime         not null
+  #  updated_at    :datetime         not null
   #
 
   factory :order do

--- a/spec/factories/region_factory.rb
+++ b/spec/factories/region_factory.rb
@@ -1,8 +1,6 @@
 FactoryBot.define do
   #  id               :integer          not null, primary key
   #  name             :string           not null
-  #  constellation_id :integer          not null
-  #  region_id        :integer          not null
   #
 
   factory :region do

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
   #  reset_password_token   :string
   #  reset_password_sent_at :datetime
   #  remember_created_at    :datetime
+  #  remember_token         :string
   #  sign_in_count          :integer          default(0), not null
   #  current_sign_in_at     :datetime
   #  last_sign_in_at        :datetime


### PR DESCRIPTION
Pre-release database cleanup, split out from the industry jobs work so the schema changes land on their own.

## Fold standalone migrations into their `create_table`

Four migrations that only patched tables created in this same repo are folded into the `create_table` that made them, then deleted:

| Deleted | Folded into |
|---|---|
| `allow_null_character_on_orders` | `create_orders` — dropped `null: false` from `t.references :character` |
| `add_reauth_required_to_characters` | `create_characters` — `t.boolean :reauth_required, default: false, null: false` |
| `add_expires_at_to_items_prices` | `create_items_prices` — `t.datetime :expires_at` |
| `make_items_prices_index_unique` | `create_items_prices` — `t.index %i[item_id star_id], unique: true` |

`create_industry_jobs` also gains the columns ESI already returns but we never stored: `facility_id`, `duration`, `successful_runs`, `cost`, `pause_date`, `completed_date`.

## Bump migration versions

Every migration after `create_characters` moves to `ActiveRecord::Migration[8.1]`. `devise_create_users` and `create_characters` stay at `[6.0]`.

## Store ESI-sourced datetimes at second precision

ESI returns whole seconds only — verified against live responses (`"issued":"2026-07-22T06:54:50Z"`, `"start_time":"2026-08-01T11:02:56Z"`) — so these columns are now `precision: 0`:

`industry_jobs.start_date` / `.end_date` / `.pause_date` / `.completed_date`, `orders.issued`, `planetary_colonies.last_update`, `items_prices.expires_at`

`created_at` / `updated_at` keep full precision — Rails sets them from `Time.current` and they order records, so truncating invites ties. `esi_expires_on` also keeps full precision: it comes from `login.eveonline.com/oauth/verify`, a different service from `esi.evetech.net`, and does carry sub-second values (`2017-07-05T14:34:16.5857101`).

## Verification

Checked out on its own, with `db/schema.rb` deleted to force a real run: all 11 migrations apply from an empty database, the regenerated schema matches the committed one exactly, and the suite is green (194 examples, 0 failures, 2 pre-existing pendings).

## Note for anyone with an existing database

Folding only takes effect on a fresh database — a database that already has `create_characters` marked `up` will never pick up `reauth_required`. Run `bin/rails db:drop db:create db:migrate` rather than `db:migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqPncbi2AwcxqGKb3yYV1C